### PR TITLE
Bugfix in common.py: 

### DIFF
--- a/sandpyper/common.py
+++ b/sandpyper/common.py
@@ -1274,7 +1274,7 @@ def extract_from_folder(
     if mode == "dsm":
         nan_out = np.count_nonzero(np.isnan(np.array(gdf.z).astype("f")))
         nan_raster = np.count_nonzero(gdf.z == nan_values)
-        gdf.z.replace(-10000, np.nan, inplace=True)
+        gdf.z.replace(nan_values, np.nan, inplace=True)
 
     elif mode == "ortho":
         nan_out = np.count_nonzero(


### PR DESCRIPTION
Code could not handle nan values correctly when nodata value in DSMs is different to -10000. I fixed the line in common.py, within the extract_from_folder function, which replaced nan values with -10000. Instead, it now replaces them with the user-defined default_nan_values (in P.extract_profiles) to match that of the SfM photogrammetric software used to generate the user's DSMs and orthomosaics.