### PR TITLE
Deprecation in common.py:

### DIFF
--- a/sandpyper/common.py
+++ b/sandpyper/common.py
@@ -630,7 +630,7 @@ def spatial_id(geometry):
     if isinstance(geometry, str):
         geom_str=list(geometry.replace(" ",""))
     else:
-        geom=geometry.to_wkt()
+        geom=geometry.wkt
         geom_str=list(geom.replace(" ",""))
 
     geom_str_rnd=random.Random(42).shuffle(geom_str)


### PR DESCRIPTION
 .to_wkt() is deprecated since around shapely 1.8. Replaced it with .wkt. 
This is not only important for future proofing, but also because the original sandpyper dependency requirements and suggested virtual environment and package versions create so many conflicts when installing SP with conda on a Mac, that it makes Sandpyper unusable.
I will make another Branch that deals with Sandpyper's cross-platform usability and share an environment .yml file with dependencies that do work on a Mac, and which uses a more recent version of some packages like shapely, thus making this fix unavoidable.